### PR TITLE
Append to lookup table

### DIFF
--- a/splunk_core/splunk_full.py
+++ b/splunk_core/splunk_full.py
@@ -273,6 +273,22 @@ class Splunk(Integration):
     # This is the magic name.
     @line_cell_magic
     def splunk(self, line, cell=None):
+        """Execute a custom line magic against a Splunk instance.
+            
+            START HERE -- Here's the general flow:
+            1.  We need to parse the user's line magic via ../utils/user_input_parser. We
+                construct an object there that has metadata. We use that object to drive
+                the rest of this function.
+            2.  We'll display errors if there were any obvious ones during parsing (this lives)
+                on the "errors" key in the object from step 1 above.
+            3.  Using the parsed input's "input" object, we'll send those to the Splunk
+                API's _handler function via ../utils/splunk_api. The _handler function
+                plays traffic cop for every API call. 
+
+        Args:
+            line (string): the user's line magic
+            cell (None, optional): user's cell magic (this shouldn't ever exist right here).
+        """
         if cell is None:
             line = line.replace("\r", "")
             line_handled = self.handleLine(line)

--- a/splunk_core/splunk_full.py
+++ b/splunk_core/splunk_full.py
@@ -7,11 +7,14 @@ from time import sleep
 from IPython.core.magic import (magics_class, line_cell_magic)
 from IPython.display import display
 import pandas as pd
-from splunklib import client as splclient
 
 from splunk_core._version import __desc__
 from integration_core import Integration
 import jupyter_integrations_utility as jiu
+
+from utils.splunk_api import SplunkAPI
+from utils.helper_functions import splunk_time, parse_times
+from utils.user_input_parser import UserInputParser
 
 @magics_class
 class Splunk(Integration):
@@ -41,6 +44,7 @@ class Splunk(Integration):
         for k in self.myopts.keys():
             self.opts[k] = self.myopts[k]
 
+        self.user_input_parser = UserInputParser()
         self.load_env(self.custom_evars)
         self.parse_instances()
 
@@ -59,7 +63,7 @@ class Splunk(Integration):
                 mypass = self.ret_dec_pass(inst["enc_pass"])
                 inst["connect_pass"] = ""
             try:
-                inst["session"] = splclient.connect(host=inst["host"], port=inst["port"], username=inst["user"], password=mypass, autologin=self.opts["splunk_autologin"][0])
+                inst["session"] = SplunkAPI(host=inst["host"], port=inst["port"], username=inst["user"], password=mypass, autologin=self.opts["splunk_autologin"][0])
                 result = 0
             except:
                 jiu.displayMD(f"**[ * ]** Unable to connect to Splunk instance {instance} at {inst['conn_url']}")
@@ -122,49 +126,6 @@ class Splunk(Integration):
             jiu.displayMD("**[ ! ]** Your query didn't contain the `latest` parameter. Defaulting to **%s**" % (self.opts[self.name_str + "_default_latest_time"][0]))
 
         return allow_run
-
-    def parseTimes(self, query):
-        """Find the "earliest" and "latest" parameter's values from the user's query, if they supplied them
-
-        Keyword arguments:
-        query -- the Splunk query supplied by the user
-
-        Returns:
-        earliest value -- the value of the "earliest" parameter
-        latest_value -- the value of the "latest" parameter
-        """
-
-        earliest_value = None
-        latest_value = None
-        
-        earliest_pattern = re.search(r"earliest ?= ?[\"\']?([^\s\'\"]+)[\s\"\']", query)
-        if earliest_pattern:
-            earliest_value = earliest_pattern.group(1)
-        
-        latest_pattern = re.search(r"latest ?= ?[\"\']?([^\s\'\"]+)[\s\"\']", query)
-        if latest_pattern:
-            latest_value = latest_pattern.group(1)
-        
-        return earliest_value, latest_value
-
-    def splunkTime(self, intime):
-        """ Converts Splunk time to the required time format for the Splunk API
-
-        Keyword arguments:
-        intime -- no idea
-
-        Returns:
-        outtime -- no idea what this is either
-        """
-        
-        m = re.search("\d{1,2}\/\d{1,2}\/\d{4}", intime)
-
-        if m:
-            tmp_dt = datetime.datetime.strptime(intime, "%m/%d/%Y:%H:%M:%S")
-            outtime = tmp_dt.strftime("%Y-%m-%dT%H:%M:%S")
-        else:
-            outtime = intime
-        return outtime
     
     def customQuery(self, query, instance, reconnect=True):
         """Execute a user supplied Splunk query after a %%splunk cell magic
@@ -186,7 +147,7 @@ class Splunk(Integration):
             if self.debug:
                 jiu.displayMD("**[ Dbg ]** Attempting to parse `earliest` and `latest` times...")
             
-            earliest_value, latest_value = self.parseTimes(query)
+            earliest_value, latest_value = parse_times(query)
             
             if self.debug:
                 if earliest_value != None:
@@ -205,8 +166,8 @@ class Splunk(Integration):
         if latest_value is None:
             latest_value = self.checkvar(instance, "splunk_default_latest_time")
 
-        earliest_value = self.splunkTime(earliest_value)
-        latest_value = self.splunkTime(latest_value)
+        earliest_value = splunk_time(earliest_value)
+        latest_value = splunk_time(latest_value)
 
         # The "exec_mode" parameter used to be a "myopts" parameter, but we've removed that
         # and hard-coded it to be "normal" since "normal" is the only search type that allows
@@ -226,7 +187,7 @@ class Splunk(Integration):
         
         # Perform the search
         try:
-            search_job = self.instances[instance]["session"].jobs.create(query, **kwargs)
+            search_job = self.instances[instance]["session"].session.jobs.create(query, **kwargs)
             jiu.displayMD(f"**[ * ]** Search job (**{search_job.name}**) has been created")
             jiu.displayMD("**Progress**")
 
@@ -315,14 +276,39 @@ class Splunk(Integration):
         if cell is None:
             line = line.replace("\r", "")
             line_handled = self.handleLine(line)
+            
             if self.debug:
                 jiu.displayMD(f"**[ Dbg ]** **line**: {line}")
                 jiu.displayMD(f"**[ Dbg ]** **cell**: {cell}")
+            
             if not line_handled: # We based on this we can do custom things for integrations. 
-                if line.lower() == "testintwin":
-                    jiu.displayMD(f"You've found the custom testint winning line magic!")
-                else:
-                    jiu.displayMD(f"I'm sorry, I don't know what you want to do with your line magic, try just {self.name_str} for help options")
+                try:
+                    parsed_input = self.user_input_parser.parse_input(line)
+                    
+                    if self.debug:
+                        jiu.displayMD(f"**[ Dbg ]** Parsed Query: `{parsed_input}`")
+                        
+                    if parsed_input["error"] == True:
+                        jiu.displayMD(f"**[ ! ]** {parsed_input['message']}")
+                        
+                    else:
+                        instance = parsed_input["input"]["instance"]
+                        dataframe = parsed_input["input"]["dataframe"]
+                        
+                        if instance not in self.instances.keys():
+                            jiu.displayMD(f"**[ * ]** Instance **{instance}** not found in instances")
+                            
+                        elif dataframe not in self.ipy.user_ns.keys():
+                            jiu.displayMD(f"**[ * ]** You supplied a dataframe **{dataframe}** that doesn't seem to exist.")
+                    
+                        else:
+                            user_dataframe = self.ipy.user_ns[dataframe]
+                            response = self.instances[instance]["session"]._handler(**parsed_input["input"], df=user_dataframe)
+                            jiu.displayMD(f"**[ * ]** {response}")
+                
+                except Exception as e:
+                    jiu.displayMD(f"**[ ! ]** There was an error in your line magic: `{e}`")
+        
         else: # This is run is the cell is not none, thus it's a cell to process  - For us, that means a query
             self.handleCell(cell, line)
 

--- a/utils/helper_functions.py
+++ b/utils/helper_functions.py
@@ -1,0 +1,45 @@
+import re
+import datetime
+
+def parse_times(query):
+    """Find the "earliest" and "latest" parameter's values from the user's query, if they supplied them
+
+    Keyword arguments:
+    query -- the Splunk query supplied by the user
+
+    Returns:
+    earliest value -- the value of the "earliest" parameter
+    latest_value -- the value of the "latest" parameter
+    """
+
+    earliest_value = None
+    latest_value = None
+    
+    earliest_pattern = re.search(r"earliest ?= ?[\"\']?([^\s\'\"]+)[\s\"\']", query)
+    if earliest_pattern:
+        earliest_value = earliest_pattern.group(1)
+    
+    latest_pattern = re.search(r"latest ?= ?[\"\']?([^\s\'\"]+)[\s\"\']", query)
+    if latest_pattern:
+        latest_value = latest_pattern.group(1)
+    
+    return earliest_value, latest_value
+
+def splunk_time(intime):
+    """ Converts Splunk time to the required time format for the Splunk API
+
+    Keyword arguments:
+    intime -- no idea
+
+    Returns:
+    outtime -- no idea what this is either
+    """
+    
+    m = re.search("\d{1,2}\/\d{1,2}\/\d{4}", intime)
+
+    if m:
+        tmp_dt = datetime.datetime.strptime(intime, "%m/%d/%Y:%H:%M:%S")
+        outtime = tmp_dt.strftime("%Y-%m-%dT%H:%M:%S")
+    else:
+        outtime = intime
+    return outtime

--- a/utils/splunk_api.py
+++ b/utils/splunk_api.py
@@ -1,0 +1,98 @@
+from splunklib import client as splclient
+import splunklib.results as results
+from time import sleep
+import jupyter_integrations_utility as jiu
+from utils.helper_functions import parse_times, splunk_time
+
+class SplunkAPI:
+    
+    def __init__(self, host, port, username, password, autologin):
+        self.session = splclient.connect(
+            host=host, 
+            port=port, 
+            username=username, 
+            password=password, 
+            autologin=autologin
+        )
+        
+    def _handler(self, command, **kwargs):
+        return getattr(self, command)(**kwargs)
+    
+    def get_lookup_table_field_names(self, lookup_table_name):
+        kwargs = { "earliest_time": "-1m",
+                  "latest_time": "now",
+                  "search_mode": "normal",
+                  "output_mode": "json"}
+        
+        query = "| inputlookup robtest.csv | stats dc(*) as * | transpose | table column"
+        
+        job = self.session.jobs.export(query, **kwargs)
+        cols = [each["column"] for each in results.JSONResultsReader(job) if isinstance(each, dict)]
+        return cols
+    
+    def update_lookup_table(self, **kwargs):
+
+
+        table = kwargs.get("table")
+        nocheck = kwargs.get("nocheck")
+        user_dataframe = kwargs.get("df")
+        
+        # If the user wants to check that their dataframe column names match up 
+        # with the field names in the Splunk lookup table, we'll do that here.
+        # If they don't, immediately return an error message and stop processing.
+        if nocheck == False:
+            try:
+                df_column_names = user_dataframe.columns.values.tolist()
+                lookup_table_field_names = self.get_lookup_table_field_names(table)
+                
+                if any(col not in lookup_table_field_names for col in df_column_names):
+                    return "There are column names in your dataframe that don't map to field names \
+                        in your lookup table, so we're not going to run this command. You can override \
+                        this by passing the --nocheck flag, but this really, _really_ isn't \
+                        recommended unless you know what you're doing."
+                
+            except Exception:
+                raise
+        
+        # Run the lookup table update command    
+        try:
+            user_dataframe_as_csv = user_dataframe.to_csv(index=False)
+            
+            kwargs_normal = { 
+                "earliest_time": "-1m", 
+                "latest_time": "now", 
+                "exec_mode": "normal"
+            }
+            
+            lookup_table_append_query = (f"| inputlookup {table}"
+                     f"| append [makeresults format=csv data=\"{user_dataframe_as_csv}\"]"
+                     f"| outputlookup {table}"
+            )
+            print(lookup_table_append_query)
+            
+            job = self.session.jobs.create(lookup_table_append_query, **kwargs_normal)
+            jiu.displayMD(f"**[ * ]** Search job (**{job.name}**) has been created")
+            jiu.displayMD("**Progress**")
+            
+            while True:
+                while not job.is_ready():
+                    pass
+
+                stats = { 
+                         "isDone": job["isDone"],
+                         "doneProgress": float(job["doneProgress"])*100
+                }
+
+                print(f"\r\t%(doneProgress)03.1f" % stats, end="")
+
+                if stats["isDone"] == "1":
+                    jiu.displayMD("**[ * ]** Job has completed!")
+                    break
+
+                sleep(1)
+            
+            return "Success"
+        
+        except Exception:
+            raise
+            

--- a/utils/user_input_parser.py
+++ b/utils/user_input_parser.py
@@ -2,6 +2,8 @@ from argparse import ArgumentParser, BooleanOptionalAction
 from utils.splunk_api import SplunkAPI
 
 class UserInputParser(ArgumentParser):
+    """A class to parse a user's line magic from Jupyter
+    """
     
     def __init__(self, *args, **kwargs):
         self.valid_commands = list(filter(lambda func : not func.startswith('_') and hasattr(getattr(SplunkAPI,func),'__call__') , dir(SplunkAPI)))
@@ -20,6 +22,15 @@ class UserInputParser(ArgumentParser):
         self.parser.parse_args([command, "--help"])
         
     def parse_input(self, input):
+        """Parses the user's line magic from Jupyter
+
+        Args:
+            input (_type_): the entire contents of the line from Jupyter
+
+        Returns:
+            parsed_input (dict): an object containing an error status, a message,
+                and parsed command from argparse.parse()
+        """
         parsed_input = {
             "error" : False,
             "message" : None,

--- a/utils/user_input_parser.py
+++ b/utils/user_input_parser.py
@@ -1,0 +1,42 @@
+from argparse import ArgumentParser, BooleanOptionalAction
+from utils.splunk_api import SplunkAPI
+
+class UserInputParser(ArgumentParser):
+    
+    def __init__(self, *args, **kwargs):
+        self.valid_commands = list(filter(lambda func : not func.startswith('_') and hasattr(getattr(SplunkAPI,func),'__call__') , dir(SplunkAPI)))
+        self.parser = ArgumentParser(prog=r"%splunk <instance>")
+        
+        self.subparsers = self.parser.add_subparsers(dest="command")
+        
+        # Subparser for "update_lookup_table" command
+        self.parser_update_lookup_table = self.subparsers.add_parser("update_lookup_table", help="Update a lookup table in Splunk")
+        self.parser_update_lookup_table.add_argument("-i", "--instance", required=True, help="the instance to run the command against")
+        self.parser_update_lookup_table.add_argument("-t", "--table", required=True, help="the lookup table to append to")
+        self.parser_update_lookup_table.add_argument("-d", "--dataframe", required=True, help="the dataframe to append to the lookup table")
+        self.parser_update_lookup_table.add_argument("--nocheck", default=False, action=BooleanOptionalAction, required=False, help="use this flag if you don't care about checking that your column headers match the field names in the Splunk lookup table (NOT RECOMMENDED!)")
+        
+    def display_help(self, command):
+        self.parser.parse_args([command, "--help"])
+        
+    def parse_input(self, input):
+        parsed_input = {
+            "error" : False,
+            "message" : None,
+            "input" : {}
+        }
+        
+        try:
+            if len(input.strip().split("\n")) > 1:
+                parsed_input["error"] = True
+                parsed_input["message"] = r"The line magic is more than one line and shouldn't be. Try `%splunk --help` or `%splunk -h` for proper formatting"
+            
+            else:
+                parsed_user_command = self.parser.parse_args(input.split())
+                parsed_input["input"].update(vars(parsed_user_command))
+        
+        except SystemExit:
+            parsed_input["error"] = True
+            parsed_input["message"] = r"Invalid input received, see the output above. Try `%splunk --help` or `%splunk -h`"
+        
+        return parsed_input


### PR DESCRIPTION
# What _didn't_ change?
I didn't change how `customQuery` functions at all, but I did extract `splunkTime` and `parseTimes` to a helper_functions file where we'll keep custom, reusable functions like this.

# What did I change?
- I added a flexible, easily extensible user input parser for line magics that leverages argparse. In order to do so, I added logic starting on line 275.
- I added the ability to update a lookup table within splunk via a line magic
- I added docstrings and documentation within