### PR TITLE
undid a previous borking with customHelp function where I left out curout from being returned

### DIFF
--- a/splunk_core/splunk_full.py
+++ b/splunk_core/splunk_full.py
@@ -280,10 +280,10 @@ class Splunk(Integration):
 
     def retCustomDesc(self):
         return __desc__
-        #return "Jupyter integration for working with the Splunk datasource"
 
-    def customHelp(self, curout):
-        out = self.retQueryHelp(None)
+    def customHelp(self, current_output):
+        out = current_output
+        out += self.retQueryHelp(None)
 
         return out
 


### PR DESCRIPTION
When I overrode the customHelp function from a previous commit, I forgot to take `curout` - which contains the current_output from the built-in `retHelp` function and prepend that to the `retQueryHelp` output. As a result, the first part of `retHelp` wasn't being displayed on screen to the user.

This undoes the borking I caused. I will work to not bork in the future.